### PR TITLE
ci: リリース時のデプロイワークフローを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  deploy-production:
+    name: Deploy Production
+    runs-on: ubuntu-24.04
+    environment: production
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Deploy
+        uses: ./.github/actions/build-deploy
+        with:
+          project-name: ishinovacojp
+          branch: ${{ vars.PAGES_BRANCH }}
+          cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## チケット

- close #16 🦕

## What

Cloudflare Pagesへの本番環境デプロイワークフローを追加

### To Be

- タグプッシュ（`v*`）時に自動でデプロイが実行される
- 手動トリガー（`workflow_dispatch`）でも実行可能
- Ubuntu 24.04環境でビルド・デプロイを実行
- セキュアな値は GitHub Secrets として管理

## How

- `.github/workflows/deploy.yml` を新規作成
  - `actions/checkout@v4.2.2` で最新のコードをチェックアウト
  - カスタムアクションの `.github/actions/setup` でビルド環境をセットアップ
  - カスタムアクションの `.github/actions/build-deploy` でビルド・デプロイを実行
  - Cloudflare Pages関連の設定は環境変数とシークレットで管理
