### PR TITLE
feat: Open Graph Protocol 関連の調整

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,3 +1,13 @@
+---
+const {
+  title: titlePrefix,
+  description = "伝統的価値観と破壊的イノベーションの統合を象徴するIshinova。和モダンと近未来感を掛け合わせたデザインで次世代のスタンダードを提案します。",
+  ogpImageURL = new URL('/ogp.png', Astro.url),
+} = Astro.props;
+
+const title = titlePrefix ? `${titlePrefix} | Ishinova` : 'Ishinova | 伝統と革新の統合';
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+---
 <!doctype html>
 <html lang="ja">
 	<head>
@@ -9,18 +19,21 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
 		<meta name="apple-mobile-web-app-title" content="Ishinova" />
 		<link rel="manifest" href="/site.webmanifest" />
+    <link rel="canonical" href={canonicalURL} />
+    <link rel="sitemap" href="/sitemap-index.xml" />
 		<meta name="generator" content={Astro.generator} />
-		<meta name="description" content="伝統的価値観と破壊的イノベーションの統合を象徴するIshinova。和モダンと近未来感を掛け合わせたデザインで次世代のスタンダードを提案します。" />
-		<meta property="og:title" content={`${Astro.props.title || 'Ishinova | 伝統と革新の統合'}`} />
-		<meta property="og:description" content="伝統的価値観と破壊的イノベーションの統合を象徴するIshinova。和モダンと近未来感を掛け合わせたデザインで次世代のスタンダードを提案します。" />
+    <meta name="description" content={description} />
+    {/* Open Graph Protocol */}
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content={import.meta.env.SITE} />
-		<meta property="og:image" content={`${import.meta.env.SITE}/ogp.png`} />
+    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:image" content={ogpImageURL} />
 		<meta name="twitter:card" content="summary_large_image" />
 		<link rel="preconnect" href="https://fonts.googleapis.com">
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 		<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
-		<title>{Astro.props.title || 'Ishinova | 伝統と革新の統合'}</title>
+    <title>{title}</title>
 	</head>
 	<body>
 		<slot />


### PR DESCRIPTION
## チケット

- close #24 🦕

## What

SEO対策の強化のため、以下の改善を実施:

- canonical URLの設定
- サイトマップの追加
- OGP関連のメタタグの最適化
- タイトルとディスクリプションの変数化による柔軟な設定対応

### As Is

- OGPやメタ情報が直接ハードコードされていた
- canonical URLやサイトマップの設定が不足
- タイトルとディスクリプションの管理が柔軟性に欠けていた

### To Be

- canonical URLとサイトマップを適切に設定し、検索エンジンのクロール効率を改善
- OGPメタタグを動的に生成し、より正確なソーシャルシェア情報を提供
- タイトルとディスクリプションをpropsで管理し、ページごとにカスタマイズ可能に

## How

- `Layout.astro`コンポーネントにprops型を定義し、タイトルやディスクリプションを動的に設定
- `Astro.url`と`Astro.site`を使用して正確なcanonical URLを生成
- OGPイメージURLをpropsで上書き可能に設定