### PR TITLE
ci: リリースPR作成ワークフローのリベース関連処理修正

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -240,17 +240,9 @@ jobs:
               return null;
             }
 
-            // 既存のPRがある場合はリセットして更新
+            // 既存のPRがある場合はリベース
             const pr = pulls[0];
             console.log(`Existing PR found: ${JSON.stringify(pr)}`);
-
-            // リセット: mainブランチの最新コミットでブランチをリセット
-            await github.rest.git.updateRef({
-              ...context.repo,
-              ref: `heads/${branchName}`,
-              sha: mainSha,
-              force: true
-            });
 
             const manifestFilePath = '.github/release-please-manifest.json';
             if (!fs.existsSync(manifestFilePath)) {
@@ -274,17 +266,10 @@ jobs:
               packageJsonContent = JSON.stringify(packageJson, null, 2);
             }
 
-            // 現在のブランチの最新コミットを取得
-            const { data: refData } = await github.rest.git.getRef({
-              ...context.repo,
-              ref: `heads/${branchName}`,
-            });
-            const currentCommitSha = refData.object.sha;
-
-            // 現在のコミットのツリーを取得
+            // mainブランチの最新コミットのツリーを取得
             const { data: commitData } = await github.rest.git.getCommit({
               ...context.repo,
-              commit_sha: currentCommitSha,
+              commit_sha: mainSha,
             });
             const currentTreeSha = commitData.tree.sha;
 
@@ -321,14 +306,15 @@ jobs:
               ...context.repo,
               message: `chore: release ${newVersion}`,
               tree: newTree.sha,
-              parents: [currentCommitSha],
+              parents: [mainSha],
             });
 
-            // ブランチの参照を更新
+            // ブランチの参照を強制更新
             await github.rest.git.updateRef({
               ...context.repo,
               ref: `heads/${branchName}`,
               sha: newCommit.sha,
+              force: true
             });
 
             // Update pull request body


### PR DESCRIPTION
## チケット

- close #27 🦕

## Why

release-plz.yml ワークフローにおいて、既存のPRの更新方法を改善する必要があります。

## What

release-plz.yml ワークフローの既存PRの更新ロジックを、リセットからリベースに変更します。

### As Is

- mainブランチの最新コミットで強制的にブランチをリセット
- その後に新しい変更を追加

### To Be

- mainブランチの最新コミットを基準に、新しい変更をリベース
- より安全で追跡可能な方法でPRを更新

## How

1. 既存のブランチリセットロジックを削除
2. mainブランチの最新コミットを基準に新しいツリーを作成
3. 新しいコミットを作成する際に、mainブランチの最新コミットを親として指定
4. force pushでブランチを更新

## Notes

この変更により、PRの更新履歴がより追跡しやすくなり、コードレビューがしやすくなります。
