### PR TITLE
ci: スラッシュコマンドでプレビューできるようワークフローを追加

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,109 @@
+name: Preview
+
+on:
+  workflow_call:
+    inputs:
+      gh-app-id:
+        required: true
+        type: string
+      ref:
+        required: true
+        type: string
+      pr_data:
+        required: true
+        type: string
+    secrets:
+      gh-app-private-key:
+        required: true
+      cloudflare-account-id:
+        required: true
+      cloudflare-api-token:
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    runs-on: ubuntu-24.04
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+
+        # https://github.com/marketplace/actions/create-github-app-token
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ inputs.gh-app-id }}
+          private-key: ${{ secrets.gh-app-private-key }}
+
+      # https://github.com/marketplace/actions/comment-pull-request
+      - uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          message: |
+            ## Deploying page with &nbsp;<a href="https://pages.dev">Cloudflare Pages</a>
+
+            :dancer: Now building ${{ github.sha }} ... :dancer:
+
+            <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">github actions run **${{ github.run_id }}**</a>
+          comment-tag: deploy-preview
+          mode: upsert
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Build & Deploy Preview
+        id: deploy
+        uses: ./.github/actions/build-deploy
+        with:
+          project-name: ishinovacojp
+          branch: ${{ inputs.ref }}
+          cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      # https://github.com/marketplace/actions/comment-pull-request
+      - if: steps.deploy.outcome == 'success'
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          message: |
+            ## Deploying page with &nbsp;<a href="https://pages.dev">Cloudflare Pages</a>
+
+            <table><tr><td><strong>Latest commit:</strong> </td><td>
+            ${{ github.sha }} (i.e. ${{ fromJson(inputs.pr_data).headRefOid }} on preview)
+            </td></tr>
+            <tr><td><strong>Status:</strong></td><td>&nbsp;✅&nbsp; Deploy successful!</td></tr>
+            <tr><td><strong>Preview URL:</strong></td><td>
+            <a href='${{ steps.deploy.outputs.deployment-url }}'>${{ steps.deploy.outputs.deployment-url }}</a>
+            </td></tr>
+            </table>
+
+            <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">github actions run **${{ github.run_id }}**</a>
+          comment-tag: deploy-preview
+          mode: recreate
+
+      # https://github.com/marketplace/actions/comment-pull-request
+      - if: failure()
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          message: |
+            ## Deploying page with &nbsp;<a href="https://pages.dev">Cloudflare Pages</a>
+
+            <table><tr><td><strong>Latest commit:</strong> </td><td>
+            ${{ github.sha }}
+            </td></tr>
+            <tr><td><strong>Status:</strong></td><td>&nbsp;:warning:&nbsp; ${{ steps.deploy.outcome == 'failure' && 'Deploy' || '**Job**' }} failure!</td></tr>
+            </table>
+
+            Check the run result and/or Cloudflare Pages.
+
+            <a href="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}">github actions run **${{ github.run_id }}**</a>
+          comment-tag: deploy-preview
+          mode: recreate

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -64,8 +64,8 @@ jobs:
         with:
           project-name: ishinovacojp
           branch: ${{ inputs.ref }}
-          cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare-account-id: ${{ secrets.cloudflare-account-id }}
+          cloudflare-api-token: ${{ secrets.cloudflare-api-token }}
 
       # https://github.com/marketplace/actions/comment-pull-request
       - if: steps.deploy.outcome == 'success'

--- a/.github/workflows/slash-command-comment.yml
+++ b/.github/workflows/slash-command-comment.yml
@@ -1,0 +1,35 @@
+name: Slash Commands Comment
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  commands-comment:
+    runs-on: ubuntu-24.04
+    steps:
+      # https://github.com/marketplace/actions/create-github-app-token
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      # https://github.com/marketplace/actions/comment-pull-request
+      - uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          message: |
+            ## Commands
+
+            | Command  | Description                                        |
+            |----------|----------------------------------------------------|
+            | /preview | この Pull Request の Preview を Cloudflare Pages にデプロイ |
+          comment-tag: slash-command
+          mode: upsert

--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -1,0 +1,88 @@
+name: Slash Command
+
+on:
+  issue_comment:
+    types:
+      - created
+
+concurrency:
+  group: slash-command-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  ########################################
+  # Common
+  ########################################
+  get-pr-info:
+    name: Get Pull Request Info
+    runs-on: ubuntu-24.04
+    if: github.event.issue.pull_request
+    outputs:
+      ref: ${{ steps.pull-request.outputs.ref }}
+      pr_data: ${{ steps.pull-request.outputs.pr_data }}
+    steps:
+      # https://github.com/marketplace/actions/create-github-app-token
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - name: Get Pull Request details
+        id: pull-request
+        run: |
+          PR_DATA=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json number,title,body,headRefName,baseRefName,headRefOid,url | jq -c .)
+          echo "ref=$(echo "${PR_DATA}" | jq -r .headRefName)" >> "$GITHUB_OUTPUT"
+          echo "pr_data=${PR_DATA}" >> "$GITHUB_OUTPUT"
+          echo "::group::PR Data"
+          echo "${PR_DATA}"
+          echo "::endgroup::"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  ########################################
+  # Preview
+  ########################################
+  preview-command:
+    name: Preview Command
+    runs-on: ubuntu-24.04
+    if: github.event.issue.pull_request
+    outputs:
+      continue: ${{ steps.preview-command.outputs.continue }}
+    steps:
+      # https://github.com/marketplace/actions/create-github-app-token
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      # https://github.com/marketplace/actions/command-action
+      - name: Preview Command
+        id: preview-command
+        uses: github/command@3f3318d2e0145c6588eaa9c6c93493ca2d7daa97 # v1.5.1
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          command: /preview
+          reaction: "eyes"
+          allowed_contexts: "pull_request"
+          skip_ci: "true"
+          skip_reviews: "true"
+
+  preview:
+    needs:
+      - get-pr-info
+      - preview-command
+    if: ${{ needs.preview-command.outputs.continue == 'true' }}
+    name: Preview
+    uses: ./.github/workflows/preview.yml
+    with:
+      gh-app-id: ${{ vars.BOT_APP_ID }}
+      ref: ${{ needs.get-pr-info.outputs.ref }}
+      pr_data: ${{ needs.get-pr-info.outputs.pr_data }}
+    secrets:
+      cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      gh-app-private-key: ${{ secrets.BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## チケット

- close #37 🦕

## What

- Cloudflare Pages を使用したプレビュー環境のデプロイワークフローを追加
- スラッシュコマンドによるプレビューデプロイの実行機能を追加

### As Is

- プレビュー環境が存在せず、変更内容の確認が本番環境でしか行えない状態

### To Be

- Pull Request 作成時に `/preview` コマンドを使用することで、Cloudflare Pages にプレビュー環境をデプロイ可能
- デプロイ状態や URL が Pull Request のコメントに自動で追加される
- プレビュー環境で変更内容の確認が可能

## How

以下のワークフローを追加:

1. `preview.yml`
   - Cloudflare Pages へのデプロイを実行
   - デプロイ状態を PR コメントに反映

2. `slash-command-comment.yml`
   - PR 作成時に利用可能なスラッシュコマンドの一覧をコメント

3. `slash-command.yml`
   - `/preview` コマンドの検知と処理
   - PR 情報の取得とプレビューデプロイの実行

## Notes

- GitHub App のトークンを使用して PR へのコメント投稿を行う
- Cloudflare の認証情報は GitHub Secrets から取得