### PR TITLE
ci: ubuntu-24.04 -> ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/assign-author-to-pr.yml
+++ b/.github/workflows/assign-author-to-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   assignAuthor:
     name: Assign author to PR
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       # https://github.com/marketplace/actions/create-github-app-token
       - name: Create GitHub App Token

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   ishinova-actions:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     if: github.event.pull_request.user.login == 'ishinova-actions[bot]'
     steps:
       # https://github.com/marketplace/actions/create-github-app-token
@@ -28,7 +28,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   devin-ai-integration:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     if: github.event.pull_request.user.login == 'devin-ai-integration[bot]'
     steps:
       # https://github.com/marketplace/actions/create-github-app-token

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy-production:
     name: Deploy Production
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     environment: production
     steps:
       # https://github.com/marketplace/actions/checkout

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       pull-requests: write
@@ -26,7 +26,7 @@ jobs:
 
   ishinova-actions:
     if: github.event.pull_request.user.login == 'ishinova-actions[bot]'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   labeler:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       # https://github.com/marketplace/actions/checkout
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ defaults:
 jobs:
   deploy-staging:
     name: Deploy Staging
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     environment: staging
     steps:
       # https://github.com/marketplace/actions/checkout

--- a/.github/workflows/manual-deploy-pages.yml
+++ b/.github/workflows/manual-deploy-pages.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     environment: ${{ github.event.inputs.environment }}
     steps:
       # https://github.com/marketplace/actions/checkout

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   docs:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       # https://github.com/marketplace/actions/checkout
       - name: Checkout

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
       gh-app-private-key: ${{ secrets.BOT_PRIVATE_KEY }}
 
   status-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs:
       - semantic-pull-request
       - action
@@ -29,7 +29,7 @@ jobs:
 
   semantic-pull-request:
     name: Semantic Pull Request
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs:
       - changes
     if: needs.changes.outputs.semantic_pr == 'true'
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   action:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: changes
     if: needs.changes.outputs.action == 'true'
     permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   validate:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     outputs:
       new-version: ${{ steps.resolve-versions.outputs.new-version }}
       notes: ${{ steps.generate_notes.outputs.body }}
@@ -75,7 +75,7 @@ jobs:
   create-pr:
     needs: validate
     if: ${{ needs.validate.outputs.action == 'create' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -112,7 +112,7 @@ jobs:
   update-pr:
     needs: validate
     if: ${{ needs.validate.outputs.action == 'update' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   create-release:
     if: ${{ github.event.pull_request.merged == true }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/slash-command-comment.yml
+++ b/.github/workflows/slash-command-comment.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   commands-comment:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       # https://github.com/marketplace/actions/create-github-app-token
       - name: Create GitHub App Token

--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -15,7 +15,7 @@ jobs:
   ########################################
   pull-request:
     name: Get Pull Request Info
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     if: github.event.issue.pull_request
     outputs:
       ref: ${{ steps.pull-request.outputs.ref }}
@@ -66,7 +66,7 @@ jobs:
   ########################################
   preview-command:
     name: Preview Command
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     if: github.event.issue.pull_request
     outputs:
       continue: ${{ steps.preview-command.outputs.continue }}

--- a/.github/workflows/wc-changes.yml
+++ b/.github/workflows/wc-changes.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   pr_type:
     name: Pull Request Type
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     outputs:
       semantic_pr: ${{ steps.check.outputs.semantic_pr }}
     steps:
@@ -45,7 +45,7 @@ jobs:
 
   changes:
     name: Changes
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     outputs:
       action: ${{ steps.filter.outputs.action }}
       any: ${{ steps.filter.outputs.changes != '[]' }}
@@ -75,7 +75,7 @@ jobs:
 
   display_outputs:
     name: Display Outputs
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs:
       - pr_type
       - changes


### PR DESCRIPTION
## チケット

- close #ISSUE_NUMBER 🦕

## Why

CI の効率化のため

## What

GitHub Actions の全ワークフローで `runs-on: ubuntu-24.04` を `runs-on: ubuntu-24.04-arm` に変更

### Breaking Changes

特になし

### As Is

- すべての GitHub Actions ワークフローが `ubuntu-24.04` ランナーで実行されていた

### To Be

- すべての GitHub Actions ワークフローが `ubuntu-24.04-arm` ランナーで実行される

## Where

- `.github/workflows/assign-author-to-pr.yml`
- `.github/workflows/auto-merge.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/labeler.yml`
- `.github/workflows/labels.yml`
- `.github/workflows/main.yml`
- `.github/workflows/manual-deploy-pages.yml`
- `.github/workflows/preview.yml`
- `.github/workflows/pull-request.yml`
- `.github/workflows/release-please.yml`
- `.github/workflows/release.yml`
- `.github/workflows/slash-command-comment.yml`
- `.github/workflows/slash-command.yml`
- `.github/workflows/wc-changes.yml`

## How

- `runs-on: ubuntu-24.04` を `runs-on: ubuntu-24.04-arm` に一括置換

## Notes

- ARM ランナーでの動作確認が必要