### PR TITLE
feat: プライバシーポリシーと利用規約ページの追加

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -13,11 +13,11 @@ const year = new Date().getFullYear();
         <div class="footer-nav">
           <h4>サイトマップ</h4>
           <ul>
-            <li><a href="#concept">コンセプト</a></li>
-            <li><a href="#features">特徴</a></li>
-            <li><a href="#vision">ビジョン</a></li>
-            <li><a href="#company">会社概要</a></li>
-            <li><a href="#contact">お問い合わせ</a></li>
+            <li><a href="/#concept">コンセプト</a></li>
+            <li><a href="/#features">特徴</a></li>
+            <li><a href="/#vision">ビジョン</a></li>
+            <li><a href="/#company">会社概要</a></li>
+            <li><a href="/#contact">お問い合わせ</a></li>
           </ul>
         </div>
         <div class="footer-social">
@@ -25,6 +25,13 @@ const year = new Date().getFullYear();
           <ul>
             <li><a href="https://x.com/ishinovainc/" target="_blank" rel="noopener noreferrer">X</a></li>
             <li><a href="https://www.instagram.com/ishinovainc/" target="_blank" rel="noopener noreferrer">Instagram</a></li>
+          </ul>
+        </div>
+        <div class="footer-legal">
+          <h4>法的情報</h4>
+          <ul>
+            <li><a href="/privacy">プライバシーポリシー</a></li>
+            <li><a href="/terms">利用規約</a></li>
           </ul>
         </div>
       </div>
@@ -64,31 +71,36 @@ const year = new Date().getFullYear();
   }
 
   .footer-nav h4,
-  .footer-social h4 {
+  .footer-social h4,
+  .footer-legal h4 {
     color: white;
     margin-bottom: 1rem;
   }
 
   .footer-nav ul,
-  .footer-social ul {
+  .footer-social ul,
+  .footer-legal ul {
     list-style: none;
     padding: 0;
     margin: 0;
   }
 
   .footer-nav li,
-  .footer-social li {
+  .footer-social li,
+  .footer-legal li {
     margin-bottom: 0.5rem;
   }
 
   .footer-nav a,
-  .footer-social a {
+  .footer-social a,
+  .footer-legal a {
     color: #ccc;
     transition: color 0.3s ease;
   }
 
   .footer-nav a:hover,
-  .footer-social a:hover {
+  .footer-social a:hover,
+  .footer-legal a:hover {
     color: var(--color-gold);
   }
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,11 +8,11 @@
       </div>
       <nav>
         <ul>
-          <li><a href="#concept">コンセプト</a></li>
-          <li><a href="#features">特徴</a></li>
-          <li><a href="#vision">ビジョン</a></li>
-          <li><a href="#company">会社概要</a></li>
-          <li><a href="#contact" class="button">お問い合わせ</a></li>
+          <li><a href="/#concept">コンセプト</a></li>
+          <li><a href="/#features">特徴</a></li>
+          <li><a href="/#vision">ビジョン</a></li>
+          <li><a href="/#company">会社概要</a></li>
+          <li><a href="/#contact" class="button">お問い合わせ</a></li>
         </ul>
         <button class="mobile-menu-button" aria-label="メニュー">
           <span></span>
@@ -161,11 +161,18 @@
   }
 
   // Anchor smooth scroll with header offset
-  document.querySelectorAll('nav ul a[href^="#"]').forEach(link => {
+  document.querySelectorAll('nav ul a[href^="/#"]').forEach(link => {
     link.addEventListener('click', e => {
+      const href = link.getAttribute('href');
+      if (window.location.pathname !== '/') {
+        // If not on home page, navigate to home with hash
+        window.location.href = href;
+        return;
+      }
+      // If on home page, smooth scroll
       e.preventDefault();
       navMenu.classList.remove('active');
-      const target = document.querySelector(link.getAttribute('href'));
+      const target = document.querySelector(href.substring(1));
       if (!target) return;
       const headerHeight = document.querySelector('header').offsetHeight;
       const topPos = target.getBoundingClientRect().top + window.pageYOffset - headerHeight;

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,220 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import '../styles/global.css';
+---
+
+<Layout title="プライバシーポリシー | Ishinova株式会社" description="Ishinova株式会社のプライバシーポリシーページです。お客様の個人情報の取り扱いについて説明しています。">
+  <Header />
+  
+  <main>
+    <section id="privacy-policy" class="privacy-policy">
+      <div class="container">
+        <h1 class="page-title">プライバシーポリシー</h1>
+        
+        <div class="policy-content">
+          <p class="last-updated">最終更新日: 2025年5月26日</p>
+          
+          <div class="policy-section">
+            <h2>1. はじめに</h2>
+            <p>Ishinova株式会社（以下、「当社」といいます）は、お客様の個人情報の保護を重要な責務と認識し、以下のプライバシーポリシーに基づき、個人情報を適切に取り扱います。</p>
+          </div>
+
+          <div class="policy-section">
+            <h2>2. 個人情報の定義</h2>
+            <p>本プライバシーポリシーにおいて「個人情報」とは、個人情報保護法に定める個人情報、すなわち、生存する個人に関する情報であって、当該情報に含まれる氏名、生年月日その他の記述等により特定の個人を識別することができるもの（他の情報と容易に照合することができ、それにより特定の個人を識別することができることとなるものを含む）をいいます。</p>
+          </div>
+
+          <div class="policy-section">
+            <h2>3. 個人情報の収集</h2>
+            <p>当社は、以下の場合に個人情報を収集することがあります：</p>
+            <ul>
+              <li>お問い合わせフォームからのご連絡時</li>
+              <li>サービスのお申し込み時</li>
+              <li>採用応募時</li>
+              <li>その他、お客様から直接または間接的に個人情報をご提供いただく場合</li>
+            </ul>
+          </div>
+
+          <div class="policy-section">
+            <h2>4. 個人情報の利用目的</h2>
+            <p>当社は、収集した個人情報を以下の目的で利用いたします：</p>
+            <ul>
+              <li>お問い合わせへの対応</li>
+              <li>サービスの提供および運営</li>
+              <li>サービスに関する情報提供</li>
+              <li>採用選考活動</li>
+              <li>法令に基づく対応</li>
+            </ul>
+          </div>
+
+          <div class="policy-section">
+            <h2>5. 個人情報の第三者提供</h2>
+            <p>当社は、以下の場合を除き、お客様の個人情報を第三者に提供することはありません：</p>
+            <ul>
+              <li>お客様の同意がある場合</li>
+              <li>法令に基づく場合</li>
+              <li>人の生命、身体または財産の保護のために必要がある場合であって、お客様の同意を得ることが困難である場合</li>
+              <li>公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合であって、お客様の同意を得ることが困難である場合</li>
+              <li>国の機関もしくは地方公共団体またはその委託を受けた者が法令の定める事務を遂行することに対して協力する必要がある場合であって、お客様の同意を得ることにより当該事務の遂行に支障を及ぼすおそれがある場合</li>
+            </ul>
+          </div>
+
+          <div class="policy-section">
+            <h2>6. 個人情報の安全管理</h2>
+            <p>当社は、個人情報の漏洩、滅失または毀損の防止その他の個人情報の安全管理のため、必要かつ適切な措置を講じます。また、個人情報を取り扱う従業員に対して、必要かつ適切な監督を行います。</p>
+          </div>
+
+          <div class="policy-section">
+            <h2>7. 個人情報の開示・訂正・削除</h2>
+            <p>お客様は、当社が保有するお客様の個人情報について、開示、訂正、削除等を請求することができます。請求を希望される場合は、本ポリシー末尾の問い合わせ先までご連絡ください。</p>
+          </div>
+
+          <div class="policy-section">
+            <h2>8. Cookieの使用について</h2>
+            <p>当社のウェブサイトでは、お客様の利便性向上のためにCookieを使用することがあります。Cookieは、お客様のコンピュータを識別することはできますが、お客様個人を特定することはできません。お客様は、ブラウザの設定によりCookieの使用を拒否することができますが、その場合、当社ウェブサイトの一部機能がご利用いただけない場合があります。</p>
+          </div>
+
+          <div class="policy-section">
+            <h2>9. プライバシーポリシーの変更</h2>
+            <p>当社は、法令の変更その他の事情により、本プライバシーポリシーを変更することがあります。変更後のプライバシーポリシーは、当社ウェブサイトに掲載した時点から効力を生じるものとします。</p>
+          </div>
+
+          <div class="policy-section">
+            <h2>10. お問い合わせ</h2>
+            <p>本プライバシーポリシーに関するお問い合わせは、以下までご連絡ください：</p>
+            <div class="contact-info">
+              <p><strong>Ishinova株式会社</strong></p>
+              <p>〒150-0002 東京都渋谷区渋谷2-19-15 宮益坂ビルディング609</p>
+              <p>Email: info@ishinova.co.jp</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <Footer />
+</Layout>
+
+<style>
+  .privacy-policy {
+    padding-top: 6rem;
+    padding-bottom: 4rem;
+    background-color: #f8f8f8;
+    min-height: 100vh;
+  }
+
+  .page-title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--color-sumi);
+    text-align: center;
+    margin-bottom: 3rem;
+    position: relative;
+    padding-bottom: 1rem;
+  }
+
+  .page-title::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100px;
+    height: 4px;
+    background: linear-gradient(90deg, var(--color-indigo) 0%, var(--color-gold) 100%);
+    border-radius: 2px;
+  }
+
+  .policy-content {
+    background-color: white;
+    border-radius: 8px;
+    padding: 3rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+    max-width: 800px;
+    margin: 0 auto;
+  }
+
+  .last-updated {
+    color: #666;
+    font-size: 0.9rem;
+    margin-bottom: 2rem;
+    text-align: right;
+  }
+
+  .policy-section {
+    margin-bottom: 2.5rem;
+  }
+
+  .policy-section h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-indigo);
+    margin-bottom: 1rem;
+  }
+
+  .policy-section p {
+    line-height: 1.8;
+    color: var(--color-sumi);
+    margin-bottom: 1rem;
+  }
+
+  .policy-section ul {
+    margin-left: 1.5rem;
+    margin-top: 0.5rem;
+  }
+
+  .policy-section li {
+    line-height: 1.8;
+    color: var(--color-sumi);
+    margin-bottom: 0.5rem;
+  }
+
+  .contact-info {
+    background-color: #f8f8f8;
+    border-left: 4px solid var(--color-indigo);
+    padding: 1.5rem;
+    margin-top: 1rem;
+    border-radius: 4px;
+  }
+
+  .contact-info p {
+    margin-bottom: 0.5rem;
+  }
+
+  @media (max-width: 768px) {
+    .privacy-policy {
+      padding-top: 5rem;
+      padding-bottom: 3rem;
+    }
+
+    .page-title {
+      font-size: 2rem;
+      margin-bottom: 2rem;
+    }
+
+    .policy-content {
+      padding: 2rem 1.5rem;
+    }
+
+    .policy-section h2 {
+      font-size: 1.3rem;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .policy-content {
+      padding: 1.5rem 1rem;
+    }
+
+    .policy-section {
+      margin-bottom: 2rem;
+    }
+
+    .policy-section h2 {
+      font-size: 1.2rem;
+    }
+  }
+</style>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,309 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import '../styles/global.css';
+---
+
+<Layout title="利用規約 | Ishinova株式会社" description="Ishinova株式会社の利用規約ページです。当社サービスのご利用条件について説明しています。">
+  <Header />
+  
+  <main>
+    <section id="terms-of-service" class="terms-of-service">
+      <div class="container">
+        <h1 class="page-title">利用規約</h1>
+        
+        <div class="terms-content">
+          <p class="last-updated">最終更新日: 2025年5月26日</p>
+          
+          <div class="terms-section">
+            <h2>第1条（適用）</h2>
+            <p>本利用規約（以下、「本規約」といいます）は、Ishinova株式会社（以下、「当社」といいます）が提供するサービス（以下、「本サービス」といいます）の利用条件を定めるものです。利用者の皆様（以下、「ユーザー」といいます）には、本規約に従って、本サービスをご利用いただきます。</p>
+          </div>
+
+          <div class="terms-section">
+            <h2>第2条（利用登録）</h2>
+            <ol>
+              <li>本サービスの利用を希望する者は、本規約に同意の上、当社の定める方法によって利用登録を申請し、当社がこれを承認することによって、本サービスの利用登録をすることができるものとします。</li>
+              <li>当社は、利用登録の申請者に以下の事由があると判断した場合、利用登録の申請を承認しないことがあり、その理由については一切の開示義務を負わないものとします。
+                <ul>
+                  <li>利用登録の申請に際して虚偽の事項を届け出た場合</li>
+                  <li>本規約に違反したことがある者からの申請である場合</li>
+                  <li>その他、当社が利用登録を相当でないと判断した場合</li>
+                </ul>
+              </li>
+            </ol>
+          </div>
+
+          <div class="terms-section">
+            <h2>第3条（ユーザーIDおよびパスワードの管理）</h2>
+            <ol>
+              <li>ユーザーは、自己の責任において、本サービスのユーザーIDおよびパスワードを適切に管理するものとします。</li>
+              <li>ユーザーは、いかなる場合にも、ユーザーIDおよびパスワードを第三者に譲渡または貸与し、もしくは第三者と共用することはできません。</li>
+              <li>当社は、ユーザーIDとパスワードの組み合わせが登録情報と一致してログインされた場合には、そのユーザーIDを登録しているユーザー自身による利用とみなします。</li>
+            </ol>
+          </div>
+
+          <div class="terms-section">
+            <h2>第4条（禁止事項）</h2>
+            <p>ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。</p>
+            <ol>
+              <li>法令または公序良俗に違反する行為</li>
+              <li>犯罪行為に関連する行為</li>
+              <li>当社、本サービスの他のユーザー、または第三者のサーバーまたはネットワークの機能を破壊したり、妨害したりする行為</li>
+              <li>当社のサービスの運営を妨害するおそれのある行為</li>
+              <li>他のユーザーに関する個人情報等を収集または蓄積する行為</li>
+              <li>不正アクセスをし、またはこれを試みる行為</li>
+              <li>他のユーザーに成りすます行為</li>
+              <li>当社のサービスに関連して、反社会的勢力に対して直接または間接に利益を供与する行為</li>
+              <li>当社、本サービスの他のユーザーまたは第三者の知的財産権、肖像権、プライバシー、名誉その他の権利または利益を侵害する行為</li>
+              <li>その他、当社が不適切と判断する行為</li>
+            </ol>
+          </div>
+
+          <div class="terms-section">
+            <h2>第5条（本サービスの提供の停止等）</h2>
+            <ol>
+              <li>当社は、以下のいずれかの事由があると判断した場合、ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
+                <ul>
+                  <li>本サービスにかかるコンピュータシステムの保守点検または更新を行う場合</li>
+                  <li>地震、落雷、火災、停電または天災などの不可抗力により、本サービスの提供が困難となった場合</li>
+                  <li>コンピュータまたは通信回線等が事故により停止した場合</li>
+                  <li>その他、当社が本サービスの提供が困難と判断した場合</li>
+                </ul>
+              </li>
+              <li>当社は、本サービスの提供の停止または中断により、ユーザーまたは第三者が被ったいかなる不利益または損害についても、一切の責任を負わないものとします。</li>
+            </ol>
+          </div>
+
+          <div class="terms-section">
+            <h2>第6条（著作権）</h2>
+            <ol>
+              <li>ユーザーは、自ら著作権等の必要な知的財産権を有するか、または必要な権利者の許諾を得た文章、画像や映像等の情報に関してのみ、本サービスを利用し、投稿ないしアップロードすることができるものとします。</li>
+              <li>ユーザーが本サービスを利用して投稿ないしアップロードした文章、画像、映像等の著作権については、当該ユーザーその他既存の権利者に留保されるものとします。</li>
+              <li>前項本文の定めにかかわらず、当社は、本サービスを利用して投稿ないしアップロードされた文章、画像、映像等について、本サービスの改良、品質の向上、または不備の是正等ならびに本サービスの周知宣伝等に必要な範囲で利用できるものとし、ユーザーは、この利用に関して、著作者人格権を行使しないものとします。</li>
+            </ol>
+          </div>
+
+          <div class="terms-section">
+            <h2>第7条（利用制限および登録抹消）</h2>
+            <ol>
+              <li>当社は、ユーザーが以下のいずれかに該当する場合には、事前の通知なく、当該ユーザーに対して、本サービスの全部もしくは一部の利用を制限し、またはユーザーとしての登録を抹消することができるものとします。
+                <ul>
+                  <li>本規約のいずれかの条項に違反した場合</li>
+                  <li>登録事項に虚偽の事実があることが判明した場合</li>
+                  <li>料金等の支払債務の不履行があった場合</li>
+                  <li>当社からの連絡に対し、一定期間返答がない場合</li>
+                  <li>本サービスについて、最終の利用から一定期間利用がない場合</li>
+                  <li>その他、当社が本サービスの利用を適当でないと判断した場合</li>
+                </ul>
+              </li>
+              <li>当社は、本条に基づき当社が行った行為によりユーザーに生じた損害について、一切の責任を負いません。</li>
+            </ol>
+          </div>
+
+          <div class="terms-section">
+            <h2>第8条（退会）</h2>
+            <p>ユーザーは、当社の定める退会手続により、本サービスから退会できるものとします。</p>
+          </div>
+
+          <div class="terms-section">
+            <h2>第9条（保証の否認および免責事項）</h2>
+            <ol>
+              <li>当社は、本サービスに事実上または法律上の瑕疵（安全性、信頼性、正確性、完全性、有効性、特定の目的への適合性、セキュリティなどに関する欠陥、エラーやバグ、権利侵害などを含みます。）がないことを明示的にも黙示的にも保証しておりません。</li>
+              <li>当社は、本サービスに起因してユーザーに生じたあらゆる損害について、当社の故意又は重過失による場合を除き、一切の責任を負いません。ただし、本サービスに関する当社とユーザーとの間の契約（本規約を含みます。）が消費者契約法に定める消費者契約となる場合、この免責規定は適用されません。</li>
+              <li>前項ただし書に定める場合であっても、当社は、当社の過失（重過失を除きます。）による債務不履行または不法行為によりユーザーに生じた損害のうち特別な事情から生じた損害（当社またはユーザーが損害発生につき予見し、または予見し得た場合を含みます。）について一切の責任を負いません。</li>
+              <li>当社は、本サービスに関して、ユーザーと他のユーザーまたは第三者との間において生じた取引、連絡または紛争等について一切責任を負いません。</li>
+            </ol>
+          </div>
+
+          <div class="terms-section">
+            <h2>第10条（サービス内容の変更等）</h2>
+            <p>当社は、ユーザーへの事前の告知をもって、本サービスの内容を変更、追加または廃止することがあり、ユーザーはこれを承諾するものとします。</p>
+          </div>
+
+          <div class="terms-section">
+            <h2>第11条（利用規約の変更）</h2>
+            <ol>
+              <li>当社は以下の場合には、ユーザーの個別の同意を要せず、本規約を変更することができるものとします。
+                <ul>
+                  <li>本規約の変更がユーザーの一般の利益に適合するとき</li>
+                  <li>本規約の変更が本サービス利用契約の目的に反せず、かつ、変更の必要性、変更後の内容の相当性その他の変更に係る事情に照らして合理的なものであるとき</li>
+                </ul>
+              </li>
+              <li>当社はユーザーに対し、前項による本規約の変更にあたり、事前に、本規約を変更する旨及び変更後の本規約の内容並びにその効力発生時期を通知します。</li>
+            </ol>
+          </div>
+
+          <div class="terms-section">
+            <h2>第12条（個人情報の取扱い）</h2>
+            <p>当社は、本サービスの利用によって取得する個人情報については、当社「プライバシーポリシー」に従い適切に取り扱うものとします。</p>
+          </div>
+
+          <div class="terms-section">
+            <h2>第13条（通知または連絡）</h2>
+            <p>ユーザーと当社との間の通知または連絡は、当社の定める方法によって行うものとします。当社は、ユーザーから、当社が別途定める方式に従った変更届け出がない限り、現在登録されている連絡先が有効なものとみなして当該連絡先へ通知または連絡を行い、これらは、発信時にユーザーへ到達したものとみなします。</p>
+          </div>
+
+          <div class="terms-section">
+            <h2>第14条（権利義務の譲渡の禁止）</h2>
+            <p>ユーザーは、当社の書面による事前の承諾なく、利用契約上の地位または本規約に基づく権利もしくは義務を第三者に譲渡し、または担保に供することはできません。</p>
+          </div>
+
+          <div class="terms-section">
+            <h2>第15条（準拠法・裁判管轄）</h2>
+            <ol>
+              <li>本規約の解釈にあたっては、日本法を準拠法とします。</li>
+              <li>本サービスに関して紛争が生じた場合には、当社の本店所在地を管轄する裁判所を専属的合意管轄とします。</li>
+            </ol>
+          </div>
+
+          <div class="terms-section">
+            <h2>第16条（お問い合わせ）</h2>
+            <p>本規約に関するお問い合わせは、以下までご連絡ください：</p>
+            <div class="contact-info">
+              <p><strong>Ishinova株式会社</strong></p>
+              <p>〒150-0002 東京都渋谷区渋谷2-19-15 宮益坂ビルディング609</p>
+              <p>Email: info@ishinova.co.jp</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <Footer />
+</Layout>
+
+<style>
+  .terms-of-service {
+    padding-top: 6rem;
+    padding-bottom: 4rem;
+    background-color: #f8f8f8;
+    min-height: 100vh;
+  }
+
+  .page-title {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--color-sumi);
+    text-align: center;
+    margin-bottom: 3rem;
+    position: relative;
+    padding-bottom: 1rem;
+  }
+
+  .page-title::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100px;
+    height: 4px;
+    background: linear-gradient(90deg, var(--color-indigo) 0%, var(--color-gold) 100%);
+    border-radius: 2px;
+  }
+
+  .terms-content {
+    background-color: white;
+    border-radius: 8px;
+    padding: 3rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+    max-width: 800px;
+    margin: 0 auto;
+  }
+
+  .last-updated {
+    color: #666;
+    font-size: 0.9rem;
+    margin-bottom: 2rem;
+    text-align: right;
+  }
+
+  .terms-section {
+    margin-bottom: 2.5rem;
+  }
+
+  .terms-section h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-indigo);
+    margin-bottom: 1rem;
+  }
+
+  .terms-section p {
+    line-height: 1.8;
+    color: var(--color-sumi);
+    margin-bottom: 1rem;
+  }
+
+  .terms-section ol {
+    margin-left: 1.5rem;
+    margin-top: 0.5rem;
+  }
+
+  .terms-section ol > li {
+    line-height: 1.8;
+    color: var(--color-sumi);
+    margin-bottom: 1rem;
+  }
+
+  .terms-section ul {
+    margin-left: 1.5rem;
+    margin-top: 0.5rem;
+    list-style-type: disc;
+  }
+
+  .terms-section ul li {
+    line-height: 1.8;
+    color: var(--color-sumi);
+    margin-bottom: 0.5rem;
+  }
+
+  .contact-info {
+    background-color: #f8f8f8;
+    border-left: 4px solid var(--color-indigo);
+    padding: 1.5rem;
+    margin-top: 1rem;
+    border-radius: 4px;
+  }
+
+  .contact-info p {
+    margin-bottom: 0.5rem;
+  }
+
+  @media (max-width: 768px) {
+    .terms-of-service {
+      padding-top: 5rem;
+      padding-bottom: 3rem;
+    }
+
+    .page-title {
+      font-size: 2rem;
+      margin-bottom: 2rem;
+    }
+
+    .terms-content {
+      padding: 2rem 1.5rem;
+    }
+
+    .terms-section h2 {
+      font-size: 1.3rem;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .terms-content {
+      padding: 1.5rem 1rem;
+    }
+
+    .terms-section {
+      margin-bottom: 2rem;
+    }
+
+    .terms-section h2 {
+      font-size: 1.2rem;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- プライバシーポリシーページ（/privacy）を追加
- 利用規約ページ（/terms）を追加
- フッターに法的情報セクションを追加し、両ページへのリンクを設置
- ヘッダーとフッターのナビゲーションリンクをすべてのページから動作するよう修正

## Test plan
- [ ] 開発サーバーでプライバシーポリシーページ（/privacy）が正しく表示されることを確認
- [ ] 開発サーバーで利用規約ページ（/terms）が正しく表示されることを確認
- [ ] 法的ページからトップページの各セクションへのリンクが正しく動作することを確認
- [ ] レスポンシブデザインが正しく適用されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)